### PR TITLE
Smarter sending and UI fixes

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -436,7 +436,11 @@ class FileFerryApp {
       } else {
         this.managers.ui?.showErrorPopup('Invalid phrase provided.');
       }
-    } else if (pathname !== '/' && pathname !== '') {
+    } else if (
+      pathname !== '/' &&
+      pathname !== '' &&
+      !pathname.startsWith('/staging')
+    ) {
       this.managers.ui?.showErrorPopup('404 Page Not Found');
     }
   }

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 
   <body class="select-none overflow-x-hidden font-[Outfit]">
     <div
-      class="min-h-screen bg-gradient-to-b from-sky-300 via-sky-400 to-blue-500
+      class="min-h-screen-dvh bg-gradient-to-b from-sky-300 via-sky-400 to-blue-500
         dark:from-slate-900 dark:via-blue-900 dark:to-blue-950 overflow-hidden relative
         flex flex-col pt-8 pb-[350px] sm:pb-[400px] md:pb-[450px]"
     >

--- a/index.html
+++ b/index.html
@@ -32,21 +32,32 @@
           (!('theme' in localStorage) &&
             window.matchMedia('(prefers-color-scheme: dark)').matches),
       );
+
+      smartHeight();
+      function smartHeight() {
+        console.log('Setting smart height');
+        document.documentElement.style.setProperty(
+          '--js-height',
+          `${window.innterHeight}px`,
+        );
+      }
     </script>
   </head>
 
-  <body class="select-none overflow-x-hidden font-[Outfit]">
+  <body
+    onresize="smartHeight()"
+    class="select-none overflow-x-hidden font-[Outfit]"
+  >
     <div
-      class="min-h-screen-dvh bg-gradient-to-b from-sky-300 via-sky-400 to-blue-500
+      class="better-scaling bg-gradient-to-b from-sky-300 via-sky-400 to-blue-500
         dark:from-slate-900 dark:via-blue-900 dark:to-blue-950 overflow-hidden relative
         flex flex-col pt-8 pb-[350px] sm:pb-[400px] md:pb-[450px]"
     >
       <!-- Stars (Dark Mode) -->
       <div
         id="starField"
-        class="absolute inset-0 overflow-hidden hidden dark:block min-h-screen"
+        class="absolute inset-0 overflow-hidden hidden dark:block"
       >
-        <!-- Stars in the upper half -->
         <div
           class="absolute top-10 left-[10%] w-1 h-1 bg-white rounded-full animate-pulse
             opacity-70"
@@ -89,7 +100,6 @@
           style="animation-delay: 0.6s"
         ></div>
 
-        <!-- Stars in the lower half -->
         <div
           class="absolute top-60 left-[10%] w-1 h-1 bg-white rounded-full animate-pulse
             opacity-60"
@@ -141,7 +151,6 @@
           style="animation-delay: 2.2s"
         ></div>
 
-        <!-- Stars near the bottom -->
         <div
           class="absolute top-100 left-[10%] w-1 h-1 bg-white rounded-full animate-pulse
             opacity-50"

--- a/src/core/FileTransferManager.ts
+++ b/src/core/FileTransferManager.ts
@@ -6,6 +6,8 @@ import {
   WritableStreamDefaultWriter as PolyfillWritableStreamDefaultWriter,
 } from 'web-streams-polyfill';
 import streamSaver from 'streamsaver';
+import { pushable } from 'it-pushable';
+import type { Pushable } from 'it-pushable';
 import type { Libp2p } from 'libp2p';
 import type { Stream, StreamHandler } from '@libp2p/interface';
 import type { AppState } from '@/core/AppState';
@@ -182,16 +184,18 @@ export class FileTransferManager {
   }
 
   /**
-   * Sends a file to a stream, chunk by chunk.
+   * Sends a file to a stream, chunk by chunk, waiting for ACKs.
    * @param stream - The stream to write to.
    * @param file - The file to send.
    * @param chunkSize - The size of each chunk in bytes.
+   * @param ackFrequency - How often to wait for an acknowledgement.
    * @internal
    */
   private async sendFileToStream(
     stream: Stream,
     file: File,
     chunkSize: number = 16_384, // the WebRTC default message size
+    ackFrequency: number = 200, // Wait for ACK every 200 chunks
   ): Promise<void> {
     try {
       const header = await this.createFileHeader(file);
@@ -201,9 +205,31 @@ export class FileTransferManager {
       const channel = (stream as any).channel as RTCDataChannel;
       const threshold = channel.bufferedAmountLowThreshold || 1024 * 64;
 
+      let resolveNextAck: (() => void) | undefined;
+      let nextAckPromise = new Promise<void>((resolve) => {
+        resolveNextAck = resolve;
+      });
+
+      const ackHandler = async (
+        source: AsyncIterable<Uint8ArrayList>,
+      ): Promise<void> => {
+        try {
+          for await (const data of source) {
+            const msg = new TextDecoder().decode(data.subarray()).trim();
+            if (msg === 'ACK' && resolveNextAck) {
+              resolveNextAck();
+            }
+          }
+        } catch (err) {
+          console.error('Error in ACK handler:', err);
+        }
+      };
+
       const fileChunks = async function* (this: FileTransferManager) {
         yield new Uint8ArrayList(encodedHeader);
         await new Promise((resolve) => setTimeout(resolve, 1));
+
+        let chunkCount = 0;
 
         for (let offset = 0; offset < file.size; offset += chunkSize) {
           if (channel.readyState !== 'open') {
@@ -217,13 +243,13 @@ export class FileTransferManager {
           );
           const chunk = new Uint8Array(await slice.arrayBuffer());
 
-          // Skip already sent bytes
           if (bytesSent < this.transferProgressBytes) {
             bytesSent += chunk.length;
             continue;
           }
 
           yield new Uint8ArrayList(chunk);
+          chunkCount++;
 
           if (channel.bufferedAmount > threshold) {
             await new Promise<void>((resolve, reject) => {
@@ -235,9 +261,8 @@ export class FileTransferManager {
                 cleanup();
                 this.closeActiveStream(stream);
                 console.log('Closing active stream due to channel close.');
-                reject();
+                reject(new Error('Stream closed by remote'));
               };
-
               const cleanup = () => {
                 channel.removeEventListener(
                   'bufferedamountlow',
@@ -245,11 +270,12 @@ export class FileTransferManager {
                 );
                 channel.removeEventListener('close', onClose);
               };
-
               channel.addEventListener(
                 'bufferedamountlow',
                 onBufferedAmountLow,
-                { once: true },
+                {
+                  once: true,
+                },
               );
               channel.addEventListener('close', onClose, { once: true });
             });
@@ -262,10 +288,21 @@ export class FileTransferManager {
             file.size,
             'send',
           );
+
+          // After sending a batch, wait for an ACK
+          if (
+            chunkCount % ackFrequency === 0 &&
+            this.transferProgressBytes <= file.size
+          ) {
+            await nextAckPromise;
+            nextAckPromise = new Promise<void>((resolve) => {
+              resolveNextAck = resolve;
+            });
+          }
         }
       }.bind(this);
 
-      await pipe(fileChunks(), stream.sink);
+      await pipe(fileChunks(), stream, ackHandler);
 
       this.progressTracker.updateProgress(
         this.transferProgressBytes,
@@ -274,7 +311,6 @@ export class FileTransferManager {
         true,
       );
 
-      // Wait for the receiver to close the stream
       while (stream.status === 'open' || stream.status === 'closing') {
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
@@ -305,6 +341,18 @@ export class FileTransferManager {
    * @internal
    */
   private async receiveFileFromStream(stream: Stream): Promise<void> {
+    const ackFrequency = 200;
+    const ackMessage = new TextEncoder().encode('ACK');
+    let chunkCount = 0;
+    const ackPushable: Pushable<Uint8Array> = pushable({ objectMode: true });
+
+    // Pipe ACKs to the sender in the background
+    pipe(ackPushable, stream.sink).catch((err) => {
+      if (err.code !== 'ERR_STREAM_RESET') {
+        console.error('Failed to pipe ACKs to sender:', err);
+      }
+    });
+
     try {
       for await (const ualistChunk of stream.source) {
         if (!ualistChunk || ualistChunk.length === 0) {
@@ -355,6 +403,10 @@ export class FileTransferManager {
               this.fileSizeFromHeader,
               'receive',
             );
+            chunkCount++;
+            if (chunkCount % ackFrequency === 0) {
+              ackPushable.push(ackMessage);
+            }
           }
         } else if (this.receivedFileWriter != null) {
           await this.receivedFileWriter.write(dataChunk);
@@ -365,6 +417,13 @@ export class FileTransferManager {
             this.fileSizeFromHeader,
             'receive',
           );
+          chunkCount++;
+          if (
+            chunkCount % ackFrequency === 0 &&
+            this.receivedBytesTotal <= this.fileSizeFromHeader
+          ) {
+            ackPushable.push(ackMessage);
+          }
         }
 
         if (
@@ -397,12 +456,13 @@ export class FileTransferManager {
           this.receivedFileWriter = null;
           await this.closeActiveStream(stream);
           this.appState.declareFinished();
-
           break;
         }
       }
     } catch (error) {
       throw error;
+    } finally {
+      ackPushable.end();
     }
   }
 

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -264,9 +264,12 @@ export class UIManager {
 
   public showReconnecting(): void {
     if (this.appState.getMode() === 'sender') {
+      this.hideElement('initialDropUI');
+      this.hideElement('fileInfoArea');
       this.hideElement('sendInProgress');
       this.showElement('reconnectingSend');
     } else if (this.appState.getMode() === 'receiver') {
+      this.hideElement('initialReceiveUI');
       this.hideElement('receiveInProgress');
       this.showElement('reconnectingReceive');
     }

--- a/styles.css
+++ b/styles.css
@@ -2,8 +2,10 @@
 @import 'tailwindcss';
 @custom-variant dark (&:where(.dark, .dark *));
 
-.min-h-screen-dvh {
+.better-scaling {
   min-height: 100dvh;
+  min-height: -webkit-fill-available;
+  height: var(--js-height);
 }
 
 @keyframes fade-in-up {

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,10 @@
 @import 'tailwindcss';
 @custom-variant dark (&:where(.dark, .dark *));
 
+.min-h-screen-dvh {
+  min-height: 100dvh;
+}
+
 @keyframes fade-in-up {
   from {
     opacity: 0;


### PR DESCRIPTION
The FileFerry Protocol now implements a TCP like Acknowledgement system. Every 200 chunks the sender will pause and wait for the receiver to send an acknowledgement. This prevents the sender just spewing as much data as possible without checking if the receiver is keeping up. It was particularly noticeable after a re-connection.

Additionally, funny scaling on mobile devices *should* now be fixed.